### PR TITLE
Fix explanation more precise

### DIFF
--- a/tutorial/05.markdown
+++ b/tutorial/05.markdown
@@ -20,7 +20,7 @@ a list, as long as it doesn't already exist as a different type.
 [LRANGE](#help) gives a subset of the list. It takes the index of the first element
 you want to retrieve as its first parameter and the index of the last element
 you want to retrieve as its second parameter. A value of -1 for the second
-parameter means to retrieve all elements in the list.
+parameter means to retrieve elements until the end of the list.
 
 <pre><code>
     <a href="#run">LRANGE friends 0 -1</a> => ["Sam","Alice","Bob"]


### PR DESCRIPTION
"A value of -1 for the second parameter means to retrieve all elements in the list" is actually imprecise and can lead to confusion. It seems like it retrieves all elements in the list without caring for the first parameter.
