### PR TITLE
Disabled spell check on the input field

### DIFF
--- a/views/index.haml
+++ b/views/index.haml
@@ -15,7 +15,7 @@
       .line.notification= tutorial 0
 
     #toolbar
-      %input#input
+      %input{:id => "input", "spellcheck" => false}
 
     #footer
       :markdown


### PR DESCRIPTION
I was trying out the redis test in Safari, and the spell check kept on auto-correcting various redis commands, leading to mistakes!

I've not used haml before but from the docs it looks correct. Sorry if not.
