### PR TITLE
move to the new travis container support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 
 rvm:
   - 1.9.3


### PR DESCRIPTION
The travis supports new containers infrastructure for CI and this moves to the new container.

Running travis before was giving the warning "This job ran on our legacy infrastructure. Please read our docs on how to upgrade" .Example (https://travis-ci.org/badboy/try.redis/jobs/66279259). 

Now after this change there is no such warning https://travis-ci.org/PradheepShrinivasan/try.redis/jobs/81616142